### PR TITLE
Fix: Resolve backend ModuleNotFoundError and API Gemini key error

### DIFF
--- a/api/app/django_settings.py
+++ b/api/app/django_settings.py
@@ -37,7 +37,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     
     # Only essential apps for API functionality
-    'backend.admin_portal',
+    'admin_portal', # Changed from 'backend.admin_portal'
     # Temporarily comment out other apps to avoid import conflicts
     # 'backend.accounts',
     # 'backend.analytics',

--- a/api/write_sqlite_key.py
+++ b/api/write_sqlite_key.py
@@ -1,0 +1,62 @@
+import sqlite3
+import argparse
+from pathlib import Path
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description="Write an encrypted API key to the SQLite database.")
+    parser.add_argument("key_name", type=str, help="The name of the API key.")
+    parser.add_argument("encrypted_key_value", type=str, help="The encrypted value of the API key.")
+    args = parser.parse_args()
+
+    key_name = args.key_name
+    encrypted_key_value = args.encrypted_key_value
+
+    try:
+        # Determine the database path relative to this script
+        # api/write_sqlite_key.py -> script_dir is api/
+        # parent is the root project directory
+        # then construct path to backend/db.sqlite3
+        script_path = Path(__file__).resolve()
+        db_path = script_path.parent.parent / "backend" / "db.sqlite3"
+
+        if not db_path.exists():
+            print(f"Error: Database file not found at {db_path}")
+            sys.exit(1)
+
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+
+        # Check if the key already exists
+        cursor.execute("SELECT id FROM admin_portal_apikeystorage WHERE key_name = ?", (key_name,))
+        row = cursor.fetchone()
+
+        if row:
+            # Key exists, UPDATE it
+            cursor.execute(
+                "UPDATE admin_portal_apikeystorage SET encrypted_key = ?, is_active = 1 WHERE key_name = ?",
+                (encrypted_key_value, key_name)
+            )
+            conn.commit()
+            print(f"Successfully updated API key: {key_name}")
+        else:
+            # Key does not exist, INSERT it
+            cursor.execute(
+                "INSERT INTO admin_portal_apikeystorage (key_name, encrypted_key, is_active, created_at, updated_at) VALUES (?, ?, 1, datetime('now'), datetime('now'))",
+                (key_name, encrypted_key_value)
+            )
+            conn.commit()
+            print(f"Successfully inserted API key: {key_name}")
+
+    except sqlite3.Error as e:
+        print(f"SQLite error: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        sys.exit(1)
+    finally:
+        if 'conn' in locals() and conn:
+            conn.close()
+
+if __name__ == "__main__":
+    main()

--- a/backend/admin_portal/management/__init__.py
+++ b/backend/admin_portal/management/__init__.py
@@ -1,0 +1,1 @@
+# This file intentionally left blank.

--- a/backend/admin_portal/management/commands/__init__.py
+++ b/backend/admin_portal/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# This file intentionally left blank.

--- a/backend/admin_portal/management/commands/set_encrypted_api_key.py
+++ b/backend/admin_portal/management/commands/set_encrypted_api_key.py
@@ -1,0 +1,33 @@
+from django.core.management.base import BaseCommand
+from backend.admin_portal.models import APIKeyStorage
+
+class Command(BaseCommand):
+    help = 'Stores an encrypted API key in the database.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('key_name', type=str, help='The name of the API key.')
+        parser.add_argument('key_value', type=str, help='The value of the API key.')
+        parser.add_argument(
+            '--print_encrypted_key',
+            action='store_true',
+            help='Print the encrypted key to stdout instead of only storing it.'
+        )
+
+    def handle(self, *args, **options):
+        key_name = options['key_name']
+        key_value = options['key_value']
+        print_encrypted_key = options['print_encrypted_key']
+
+        api_key_object = APIKeyStorage.store_api_key(key_name, key_value)
+
+        if print_encrypted_key:
+            # Fetch the key object again to ensure we have the latest state,
+            # or use the returned object if store_api_key returns it.
+            # Assuming store_api_key returns the saved object.
+            encrypted_key_value = api_key_object.encrypted_key
+            self.stdout.write(f"Encrypted key: {encrypted_key_value}")
+
+        self.stdout.write(self.style.SUCCESS(
+            f"API key '{key_name}' stored successfully." +
+            (" It was also printed to stdout." if print_encrypted_key else "")
+        ))

--- a/backend/analytics/apps.py
+++ b/backend/analytics/apps.py
@@ -2,7 +2,7 @@ from django.apps import AppConfig
 
 class AnalyticsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'backend.analytics'
+    name = "analytics"
     
     def ready(self):
         # Import signal handlers

--- a/backend/dashboard/apps.py
+++ b/backend/dashboard/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 class DashboardConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
-    name = 'backend.dashboard'
+    name = "dashboard"

--- a/backend/notifications/apps.py
+++ b/backend/notifications/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class NotificationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    name = "backend.notifications"
+    name = "notifications"


### PR DESCRIPTION
Fixes backend ModuleNotFoundError:
- I modified analytics/apps.py, dashboard/apps.py, and notifications/apps.py to use simple app names (e.g., 'analytics') in their AppConfig 'name' attribute instead of 'backend.appname'. This resolves issues with Django's app loading mechanism.

Addresses API Gemini key decryption and setup:
- I created a Django management command `set_encrypted_api_key` (in admin_portal app) to allow storing API keys encrypted in the main PostgreSQL database. The command can also print the encrypted key.
- I created `api/write_sqlite_key.py` to enable writing a pre-encrypted key to the API's separate SQLite database, ensuring the API can access a correctly encrypted key.
- I updated `api/app/django_settings.py` to correctly reference `'admin_portal'` in `INSTALLED_APPS`.

Note on Verification:
Automated server startup checks timed out. Static analysis suggests the primary errors are resolved, but manual verification of Django and API server startup and functionality is required.